### PR TITLE
data-colors fix

### DIFF
--- a/gauge.js
+++ b/gauge.js
@@ -930,7 +930,6 @@ domReady( function() {
 								}
 								else {
 									cfgProp.shift();
-									cfgProp.shift();
 									config.colors[toCamelCase( cfgProp)] = attrValue;
 								}
 							}


### PR DESCRIPTION
## Hey, thanks for this library.

Before the fix, to set the plate color (plate is used as exemple, any
        data-color property would fail), it was necessary to declare

```
data-color-XXX-plate = '#aaa'
```

After the fix:

```
data-color-plate = '#aaa'
```

As the docs suggest.
