### PR TITLE
Fixed Animation Bug

### DIFF
--- a/gauge.js
+++ b/gauge.js
@@ -284,7 +284,7 @@ var Gauge = function( config) {
 			delay    : cfg.delay,
 			duration : cfg.duration,
 			delta    : cfg.fn,
-			step     : function( delta) { fromValue = from + path * delta; self.draw(); }
+			step     : function( delta) { fromValue = parseFloat(from) + path * delta; self.draw(); }
 		});
 	};
 


### PR DESCRIPTION
Sometimes the needle would point directly down (as the angle was set to NaN).

The fromValue was getting the angle difference appended to it as a string, rather than calculating the value.

This was especially evident in small value changes.
