### PR TITLE
Removed unused variable assignment in ternary function.

### DIFF
--- a/gauge.js
+++ b/gauge.js
@@ -95,7 +95,7 @@ var Gauge = function( config) {
 		var dv = (config.maxValue - config.minValue) / 100;
 
 		toValue = val > config.maxValue ?
-			toValue = config.maxValue + dv :
+			config.maxValue + dv :
 				val < config.minValue ?
 					config.minValue - dv : 
 						val


### PR DESCRIPTION
...already was assigning its value to toValue. This likely was not causing a bug, but could cause compilers to less efficient, and some IDE's validations may not like it.
