### PR TITLE
Resolved 2 errors caused under 'use strict' mode. 

### DIFF
--- a/gauge.js
+++ b/gauge.js
@@ -303,7 +303,7 @@ var Gauge = function( config) {
 			cctx.clearRect( -CX, -CY, CW, CH);
 			cctx.save();
 
-			var tmp = ctx;
+			var tmp = {ctx:ctx};
 			ctx = cctx;
 
 			drawPlate();
@@ -315,8 +315,8 @@ var Gauge = function( config) {
 			drawUnits();
 
 			cache.i8d = true;
-			ctx = tmp;
-			delete tmp;
+			ctx = tmp.ctx;
+			delete tmp.ctx;
 		}
 
 		// clear the canvas
@@ -379,9 +379,8 @@ var Gauge = function( config) {
 			r1 = max / 100 * 91,
 			d1 = max - r1,
 			r2 = max / 100 * 88,
-			d2 = max - r2;
-			r3 = max / 100 * 85
-		;
+			d2 = max - r2,
+			r3 = max / 100 * 85;
 
 		ctx.save();
 


### PR DESCRIPTION
...t' mode. First was a "Uncaught SyntaxError: Delete of an unqualified identifier in strict mode." caused by the delete of the tmp variable. The second was r3 not being defined because of a misplaced comma.

Sorry I am not including a new min version, I could not sport which compressor/compiler you used. Shoot me and email with that and I will re-compile the min file too if you like. 
