### PR TITLE
fixed bug when creating with objects and then trying to access via Gauge.Collection

### DIFF
--- a/gauge.js
+++ b/gauge.js
@@ -900,7 +900,8 @@ Gauge.Collection.get = function( id) {
 
 	if (typeof(id) == 'string') {
 		for (var i = 0, s = self.length; i < s; i++) {
-			if (self[i].config.renderTo.getAttribute( 'id') == id) {
+			var canvas = self[i].config.renderTo.tagName ? self[i].config.renderTo : document.getElementById( self[i].config.renderTo);
+			if (canvas.getAttribute('id') == id) {
 				return self[i];
 			}
 		}


### PR DESCRIPTION
This fixes a problem I ran into when I created a gauge in javascript but then later tried to get the gauge out go Gauge.Collection the config.renderTo was the name of the gauge canvas and not the actual canvas.
