### PR TITLE
Correct needle placement when minimun value in nonzero

### DIFF
--- a/gauge.js
+++ b/gauge.js
@@ -818,18 +818,10 @@ var Gauge = function (config) {
 
         ctx.save();
 
-        if (fromValue < 0) {
-            fromValue = Math.abs(config.minValue - fromValue);
-        } else if (config.minValue > 0) {
-            fromValue -= config.minValue
-        } else {
-            fromValue = Math.abs(config.minValue) + fromValue;
-        }
-
         ctx.rotate(
             radians(
-                config.startAngle + fromValue /
-                ((config.maxValue - config.minValue) / config.ticksAngle)
+                config.startAngle + (fromValue-config.minValue) /
+                (config.maxValue - config.minValue) * config.ticksAngle
             )
         );
 


### PR DESCRIPTION
When the minimum value of a gauge is not zero, the needle is not correctly placed, a in the second and third gauges of the the following example
```html
<canvas
   id="test1"
   data-type="canv-gauge"
   width="200"
   height="200"
   data-value="150"
   data-min-value="0"
   data-max-value="250"
   data-major-ticks="0 50 100 150 200 250"
  ></canvas>

  <canvas
   id="test2"
   data-type="canv-gauge"
   width="200"
   height="200"
   data-value="150"
   data-min-value="50"
   data-max-value="250"
   data-major-ticks="50 100 150 200 250"
  ></canvas>

  <canvas
   id="test3"
   data-type="canv-gauge"
   width="200"
   height="200"
   data-value="150"
   data-min-value="100"
   data-max-value="250"
   data-major-ticks="100 150 200 250"
  ></canvas>
```
This pull request solves the issue.