### PR TITLE
Attempt to fix context stack overflow #155

### DIFF
--- a/lib/RadialGauge.js
+++ b/lib/RadialGauge.js
@@ -974,7 +974,6 @@ export default class RadialGauge extends BaseGauge {
 
                 // clear the canvas
                 canvas.context.clearRect(x, y, w, h);
-                canvas.context.save();
 
                 canvas.context.drawImage(canvas.elementClone, x, y, w, h);
                 canvas.context.save();


### PR DESCRIPTION
This context.save() did not have any use as it was always followed by another context.save() 2 lines down.

This seems to be the cause of #155 but there might be more `context.save()` calls that have to be checked.