### PR TITLE
Declare isFixed before it's used (#1)

### DIFF
--- a/lib/RadialGauge.js
+++ b/lib/RadialGauge.js
@@ -497,6 +497,7 @@ function drawRadialUnits(context, options) {
  */
 function drawRadialNeedle(context, options) {
     if (!options.needle) return;
+    let isFixed = options.animationTarget !== 'needle';
 
     let value = options.ticksAngle < 360 ?
         drawings.normalizedValue(options).indented : options.value;
@@ -522,7 +523,6 @@ function drawRadialNeedle(context, options) {
     let pad1 = max / 100 * options.needleWidth;
     let pad2 = max / 100 * options.needleWidth / 2;
     let pixelRatio = SmartCanvas.pixelRatio;
-    let isFixed = options.animationTarget !== 'needle';
 
     context.save();
 


### PR DESCRIPTION
isFixed is used on line 504 before it is declared. Since it is undefined/null when tested, startAngle is not fixed in when plate it the animation target