### PR TITLE
[fix] numeric value box shows with negative sign on the right when canvas is RTL (Closes #244)

### DIFF
--- a/lib/drawings.js
+++ b/lib/drawings.js
@@ -389,7 +389,12 @@ export function drawValueBox(context, options, value, x, y, max) {
         .concat(options.majorTicks.map(val =>
             String(parseInt(val, 10)).length + addLength
         ))));
-    let text = options.valueText || padValue(value, options);
+    let text = options.valueText;
+	if (!text) {
+		text = padValue(value, options);
+		if (context.direction === 'rtl')
+			text = '\u200e' + text; // Force the numeric value to be LTR
+	}
     let tunit = max / 200;
     let runit = max / 100;
     let offset = 0.4 * runit;


### PR DESCRIPTION
Closes #244 