### PR TITLE
correctly handle animationTarget != needle for radial gauges

### DIFF
--- a/lib/RadialGauge.js
+++ b/lib/RadialGauge.js
@@ -498,6 +498,7 @@ function drawRadialUnits(context, options) {
 function drawRadialNeedle(context, options) {
     if (!options.needle) return;
 
+    let isFixed = options.animationTarget !== 'needle';
     let value = options.ticksAngle < 360 ?
         drawings.normalizedValue(options).indented : options.value;
         let startAngle = isFixed ? options.startAngle :
@@ -522,7 +523,6 @@ function drawRadialNeedle(context, options) {
     let pad1 = max / 100 * options.needleWidth;
     let pad2 = max / 100 * options.needleWidth / 2;
     let pixelRatio = SmartCanvas.pixelRatio;
-    let isFixed = options.animationTarget !== 'needle';
 
     context.save();
 


### PR DESCRIPTION
When trying to use the radial gauge with animationTarget == 'plate', the needle still moves with the value.
It's basically a wrong order of the assignments.